### PR TITLE
fix: fonts are inaccessible (fix #40)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const removeMd = require('remove-markdown')
-
+const path = require('path')
 module.exports = (themeConfig, ctx) => {
   themeConfig = Object.assign(themeConfig, {
     nav: themeConfig.nav || [
@@ -78,6 +78,9 @@ module.exports = (themeConfig, ctx) => {
       THEME_BLOG_PAGINATION_COMPONENT: themeConfig.paginationComponent
         ? themeConfig.paginationComponent
         : 'Pagination',
+    },
+    alias: {
+      fonts: path.resolve(__dirname, 'fonts'),
     },
   }
 

--- a/styles/font.styl
+++ b/styles/font.styl
@@ -3,7 +3,7 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
-  src: local('PT Serif'), local('PTSerif-Regular'), url(/fonts/EJRVQgYoZZY2vCFuvAFbzr-_dSb_nco.woff2) format('woff2');
+  src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFbzr-_dSb_nco.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 /* cyrillic */
@@ -11,7 +11,7 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
-  src: local('PT Serif'), local('PTSerif-Regular'), url(/fonts/EJRVQgYoZZY2vCFuvAFSzr-_dSb_nco.woff2) format('woff2');
+  src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFSzr-_dSb_nco.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* latin-ext */
@@ -19,7 +19,7 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
-  src: local('PT Serif'), local('PTSerif-Regular'), url(/fonts/EJRVQgYoZZY2vCFuvAFYzr-_dSb_nco.woff2) format('woff2');
+  src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFYzr-_dSb_nco.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -27,6 +27,6 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
-  src: local('PT Serif'), local('PTSerif-Regular'), url(/fonts/EJRVQgYoZZY2vCFuvAFWzr-_dSb_.woff2) format('woff2');
+  src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFWzr-_dSb_.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Relevant PR: #43 
Relevant issue: #40 

Why the fonts are inaccessible?

Because our style is implemented by `index.stly`([ref1](https://vuepress.vuejs.org/config/#index-styl),[ref2](https://vuepress.vuejs.org/miscellaneous/design-concepts.html#overriding))

`index.stly` will be generated into the final CSS file in the `ready` phase ([source code](https://github.com/vuejs/vuepress/blob/master/packages/%40vuepress/core/lib/node/internal-plugins/style/index.js)). `ready` is executed before creating webpack config, you can take a look at [my post](https://billyyyyy3320.com/en/2019/09/08/dive-into-vuepress-with-plugin-apis/).

We definitely can't refer our path such as, `url(/fonts/EJRVQgYoZZY2vCFuvAFbzr-_dSb_nco.woff2)` because we are in the `temp` dir.

Leveraging webpack alias is a better approach than what I did in #43 to resolve it.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:


