### PR TITLE
fix: `location` shouldn't be required when setting `author` in front …

### DIFF
--- a/global-components/BaseListLayout.vue
+++ b/global-components/BaseListLayout.vue
@@ -13,10 +13,10 @@
 
         <div v-if="page.frontmatter.author" class="ui-post-meta ui-post-author">
           <NavigationIcon />
-          <span
-            >{{ page.frontmatter.author }} in
-            {{ page.frontmatter.location }}</span
-          >
+          <span>{{ page.frontmatter.author }}</span>
+          <span v-if="page.frontmatter.location">
+            &nbsp; in {{ page.frontmatter.location }}
+          </span>
         </div>
 
         <div v-if="page.frontmatter.date" class="ui-post-meta ui-post-date">


### PR DESCRIPTION

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

Currently, no matter `location` is provided, the text `in` is displayed when `author` is set up in front matter.

But people should be allow to set `author` without setting `location`.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
