### PR TITLE
fix: web feed link should be absolute path

### DIFF
--- a/components/Feed.vue
+++ b/components/Feed.vue
@@ -2,7 +2,7 @@
   <a
     v-if="getFirstEnabledFeed"
     class="feed"
-    :href="getFirstEnabledFeed | getFeedFileName"
+    :href="getFirstEnabledFeed | getFeedFilePath"
   >
     <RssIcon />
   </a>
@@ -14,10 +14,10 @@ import { RssIcon } from 'vue-feather-icons'
 export default {
   components: { RssIcon },
   filters: {
-    getFeedFileName(feed) {
-      if (feed === 'rss') return 'rss.xml'
-      if (feed === 'atom') return 'feed.atom'
-      if (feed === 'json') return 'feed.json'
+    getFeedFilePath(feed) {
+      if (feed === 'rss') return '/rss.xml'
+      if (feed === 'atom') return '/feed.atom'
+      if (feed === 'json') return '/feed.json'
       return ''
     },
   },


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The link of feed icon is broken in any page except `/` because it's using relative path.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
