### PR TITLE
imp(fonts) use font-display swap to prevent FOIT

### DIFF
--- a/styles/font.styl
+++ b/styles/font.styl
@@ -3,6 +3,7 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFbzr-_dSb_nco.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
@@ -11,6 +12,7 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFSzr-_dSb_nco.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -19,6 +21,7 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFYzr-_dSb_nco.woff2') format('woff2');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -27,6 +30,7 @@
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
+  font-display: swap;
   src: local('PT Serif'), local('PTSerif-Regular'), url('~fonts/EJRVQgYoZZY2vCFuvAFWzr-_dSb_.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }

--- a/styles/index.styl
+++ b/styles/index.styl
@@ -73,7 +73,7 @@ strong
 h1, h2, h3, h4, h5, h6
   font-weight 600
   line-height 1.25
-  font-family PT Serif
+  font-family PT Serif, Serif
 
   {$contentClass}:not(.custom) > &
     margin-top 'calc(0.5rem - %s)' % ($headerHeight)


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When the custom font `PT Serif` is downloading, headings are not visible until the custom font is downloaded. 
This is what we call Flash Of Invisible Text (FOIT).

To prevent this, we cant set `@font-display: swap` to:
- use the fallback font when `PT Serif` is being downloaded
- use `PT Serif` when it's downloaded

This is called Flash on Unstyled Text (FOUT), and it's preferable over FOIT since you can directly see the content.

Read more at: https://css-tricks.com/font-display-masses/

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

. 

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 80.0.3987.116
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
