### PR TITLE
fix: cannot click tag labels on outside of the text (fix #84)

### DIFF
--- a/components/PostTag.vue
+++ b/components/PostTag.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="post-tag">
-    <router-link :to="'/tag/' + tag"> {{ tag }} </router-link>
+    <router-link :to="'/tag/' + tag"><span>{{ tag }}</span></router-link>
   </li>
 </template>
 
@@ -18,48 +18,51 @@ export default {
 
 <style scoped lang="stylus">
 .post-tag
-  background-color $postTagBgColor
-  border-radius 3px 0 0 3px
-  height 26px
-  padding 0 20px 0 23px
-  position relative
-  cursor pointer
+    height 26px
 
   &:not(:last-child)
     margin-right 10px
 
   a
-    color $postTagColor
+    background-color $postTagBgColor
+    border-radius 3px 0 0 3px
+    padding 0 20px 0 23px
+    position relative
     text-decoration none
-    transition color 0.2s
+    height 26px
+    display inline-block
 
-  &:before
-    position absolute
-    left 10px
-    top 10px
-    background #fff
-    border-radius 50%
-    box-shadow inset 0 1px rgba(0, 0, 0, 0.25)
-    content ''
-    height 6px
-    width 6px
+    span
+      color $postTagColor
+      transition color 0.2s
 
-  &:after
-    position absolute
-    right 0
-    top 0
-    background $bgColor
-    border-bottom 13px solid transparent
-    border-left 10px solid $postTagBgColor
-    border-top 13px solid transparent
-    content ''
-
-  &:hover
-    background-color $accentColor
+    &:before
+      position absolute
+      left 10px
+      top 10px
+      background #fff
+      border-radius 50%
+      box-shadow inset 0 1px rgba(0, 0, 0, 0.25)
+      content ''
+      height 6px
+      width 6px
 
     &:after
-      border-left-color $accentColor
+      position absolute
+      right 0
+      top 0
+      background $bgColor
+      border-bottom 13px solid transparent
+      border-left 10px solid $postTagBgColor
+      border-top 13px solid transparent
+      content ''
 
-    a
-      color #fff
+    &:hover
+      background-color $accentColor
+
+      &:after
+        border-left-color $accentColor
+
+      span
+        color #fff
 </style>

--- a/components/PostTag.vue
+++ b/components/PostTag.vue
@@ -1,6 +1,8 @@
 <template>
   <li class="post-tag">
-    <router-link :to="'/tag/' + tag"><span>{{ tag }}</span></router-link>
+    <router-link :to="'/tag/' + tag">
+      <span>{{ tag }}</span>
+    </router-link>
   </li>
 </template>
 


### PR DESCRIPTION
fixes #84

The diff is huge, mainly due to additionnal nesting (causing more indent in the style).

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
